### PR TITLE
Use single bidirectional arrow for two-way deps

### DIFF
--- a/objc_dep.py
+++ b/objc_dep.py
@@ -163,7 +163,6 @@ def dependencies_in_dot_format(path, exclude, ignore):
     l = []
     l.append("digraph G {")
     l.append("\tnode [shape=box];")
-    two_ways = Set()
 
     for k, deps in d.iteritems():
         if deps:
@@ -173,10 +172,8 @@ def dependencies_in_dot_format(path, exclude, ignore):
             l.append("\t\"%s\" -> {};" % (k))
         
         for k2 in deps:
-            if (k, k2) in two_ways_set or (k2, k) in two_ways_set:
-                two_ways.add((k, k2))
-            else:
-                l.append("\t\"%s\" -> \"%s\";" % (k, k2))
+	        if not ((k, k2) in two_ways_set or (k2, k) in two_ways_set):
+	            l.append("\t\"%s\" -> \"%s\";" % (k, k2))
 
     l.append("\t")
     for (k, v) in pch_set.iteritems():
@@ -185,9 +182,9 @@ def dependencies_in_dot_format(path, exclude, ignore):
             l.append("\t\"%s\" -> \"%s\" [color=red];" % (k, x))
     
     l.append("\t")
-    l.append("\tedge [color=blue];")
+    l.append("\tedge [color=blue, dir=both];")
 
-    for (k, k2) in two_ways:
+    for (k, k2) in two_ways_set:
         l.append("\t\"%s\" -> \"%s\";" % (k, k2))
     
     if category_list:


### PR DESCRIPTION
Hi,

I've been using objc_dep to clean up some header cruft. I changed your code around a little to use bidirectional arrows for two-way dependencies; use it if you like.

-Mikkel
